### PR TITLE
Added option to include system fields

### DIFF
--- a/lib/wuparty.rb
+++ b/lib/wuparty.rb
@@ -303,6 +303,10 @@ class WuParty
         query[:pageStart] = 0
       end
 
+      if options[:system]
+        query[:system] = true
+      end
+
       if options[:sort]
         field, direction = options[:sort].split(' ')
         query[:sort] = field
@@ -328,6 +332,11 @@ class WuParty
           query["Filter#{ index + 1 }"] = filter.join(' ')
         end
       end   
+
+      if options[:system]
+        query[:system] = true
+      end
+
       @party.get("forms/#{@id}/entries/count", :query => query)['EntryCount']
     end
 


### PR DESCRIPTION
Hey! Thanks for the merge.  Here's another one for you.  This gives you the option to include system fields.  

I found this was useful because Wufoo's API returns ALL entries, including ones that are incomplete which was causing discrepancies with our app and what Wufoo was reporting.  Now you can run a query like:

``` ruby
wufoo.count(:system => true, :filters => [['CompleteSubmission','Is_equal_to',1]])
```

to only return completed entries.  
