### PR TITLE
Added support for the pageStart parameter

### DIFF
--- a/lib/wuparty.rb
+++ b/lib/wuparty.rb
@@ -300,7 +300,10 @@ class WuParty
 
       if options[:limit]
         query[:pageSize] = options[:limit]
-        query[:pageStart] = 0
+      end
+
+      if options[:pageStart]
+        query[:pageStart] = options[:pageStart]
       end
 
       if options[:system]


### PR DESCRIPTION
Since the max value on pageSize is 100, and some wufoo forms will have more than 100 entries I have added support for the pageStart parameter. Also, note that I removed query[:pageStart] = 0 from the conditional for the limit option. PageStart defaults to zero anyhow, and this is necessary to be able to use the PageStart and PageSize parameters together. To correctly illustrate how these two are used together, I'll share this example from wufoo's api documentation:

"So, if you’re filtering for all entries where Field1 Contains Bob and the filter returned 1000 entries, and you set pageStart=0 and pageSize=25 you’d end up with the first 25 entries which fit the filter. If you up the pageStart to 25 and left the pageSize the same, you’d get the next 25 entries."
