### PR TITLE
Add support for returning field choices.

### DIFF
--- a/lib/wuparty.rb
+++ b/lib/wuparty.rb
@@ -259,6 +259,7 @@ class WuParty
     #    {'ID' => 'Field2', 'Title' => 'Name - Last',  'Type' => 'shortname', 'Required' => true }, # (subfield)
     #    {'ID' => 'Field3', 'Title' => 'Birthday',     'Type' => 'date',      'Required' => flase}] # (field)
     # By default, only fields that can be submitted are returned. Pass *true* as the first arg to return all fields.
+    # Add ability to return choices for multiple-choice form fields?
     def flattened_fields(all=false)
       flattened = []
       fields.each do |field|


### PR DESCRIPTION
No code modifications here, just a suggestion to discuss. The [Fields API Standard Fields](http://help.wufoo.com/articles/en_US/SurveyMonkeyArticleType/The-Fields-API#Standardfields) allows for the return of the [choices](http://help.wufoo.com/articles/en_US/SurveyMonkeyArticleType/The-Fields-API#choices) present in a multiple choice question . It'd be beneficial in my particular use case to be able to query these choices and use them dynamically. Apologies for ignorance, here, if this is currently possible via the sub-fields functionality, but it doesn't appear to be.
